### PR TITLE
Make -appendObject: Typesafe

### DIFF
--- a/BRYHashCodeBuilder/BRYHashCodeBuilder.h
+++ b/BRYHashCodeBuilder/BRYHashCodeBuilder.h
@@ -33,7 +33,7 @@
  */
 + (instancetype)builderWithInitialValue:(NSUInteger)initial multiplier:(NSUInteger)multiplier;
 
-- (BRYHashCodeBuilder *)appendObject:(id)object;
+- (BRYHashCodeBuilder *)appendObject:(id <NSObject>)object;
 
 - (BRYHashCodeBuilder *)appendInteger:(NSInteger)integer;
 


### PR DESCRIPTION
`-[BRYHashCodeBuilder appendObject:]` uses `-hash` internally, which is declared in the `NSObject` protocol. This isn't a problem when using the code from Objective-C, where (more or less) all objects inherit from `NSObject` and conform to the `NSObject` protocol, but it's a big problem when dealing with Swift interop.
